### PR TITLE
Add Categories PDF generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 mulberry-symbols.zip
+categories.pdf

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # mulberry-symbols
-The Mulberry Symbols are collection of pictograms / symbols / icons designed for AAC users who rely on graphics symbols for communication with others. They include more unusual symbols, including many suitable for adult AAC users. Thesymbols are freely usable, sharable and modifiable having a liberal Creative Commons licence. Thus they are perfect for using in on-line applications as there are no licence fees to concider.
 
-The symbols are provided in Scalable Vector Format (SVG) so they look good at any size. We've always preferred this format and it is now readily usable on the web and other platforms. If you want a fixed size raster image there are various SVG tools that alow you to convert to the ressolution that you require. 
+The Mulberry Symbols are collection of pictograms / symbols / icons designed for AAC users who rely on graphics symbols for communication with others. They include more unusual symbols, including many suitable for adult AAC users. The symbols are freely usable, sharable and modifiable having a liberal Creative Commons license. Thus they are perfect for using in on-line applications as there are no license fees to consider.
+
+The symbols are provided in Scalable Vector Format (SVG) so they look good at any size. We've always preferred this format and it is now readily usable on the web and other platforms. If you want a fixed size raster image there are various SVG tools that allow you to convert to the resolution that you require.
 
 See https://mulberrysymbols.org for more details
 
@@ -12,7 +13,7 @@ This is a typical npm/node managed package.
 Two npm scripts are provided in `package.json`
 
 1. test - checks the symbols names against the `symbol-info.csv`
-1. build - generates the .zip for distibution 
+1. build - generates the .zip for distribution
 
 ## Releases
 
@@ -23,5 +24,6 @@ Currently this is a manual process.
 1. Execute `npm run build` to build the zip
 1. Make a GitHub Release with Tag of `v<RELEASE NUMBER>`, adding release notes
 1. Add the zip to the release
+1. Add the Categories PDF to the release
 1. Announce the release
 1. Perform `git pull` to get the release tag locally

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,41 +2,41 @@
 
 We believe that communication is a fundamental human right. Many people with impaired speech and other language difficulties require symbols to support their communication needs, to enable their desires, wishes and opinions to be expressed.
 
-These symbols are provided as a "free at the point of use" resource for speech and language professionals (SLTs) or developers to use in communication aids or to print. We also hope exciting new uses will be created so we have used a liberal Creative Commons licence.
+These symbols are provided as a "free at the point of use" resource for speech and language professionals (SLTs) or developers to use in communication aids or to print. We also hope exciting new uses will be created so we have used a liberal Creative Commons license.
 
-* Designed to overcome high costs experienced by symbols users - free at point of use
-* Foster innovation by alowing reuse and derivations, including internationalisation and use in web apps.
-* Adult oriented symbols - most proprietary sets are designed for children
-* Features unusual symbols usually missing from proprietary sets
-* Designed by graphic artists, reviewed by community and coloured by SLTs overseeing volunteers who had mental health issues
-* Symbols and design process originated by Garry Paxton who then assigned copyright over to Steve Lee in 2018
+- Designed to overcome high costs experienced by symbols users - free at point of use
+- Foster innovation by allowing reuse and derivations, including internationalisation and use in web apps.
+- Adult oriented symbols - most proprietary sets are designed for children
+- Features unusual symbols usually missing from proprietary sets
+- Designed by graphic artists, reviewed by community and coloured by SLTs overseeing volunteers who had mental health issues
+- Symbols and design process originated by Garry Paxton who then assigned copyright over to Steve Lee in 2018
 
 # Downloads
 
-* A [zip of all the symbols](https://github.com/mulberrysymbols/mulberry-symbols/releases/latest) in SVG format, including a spreadsheet with categories, tags and rating (large file)
-* A [PDF of the symbols](https://cdn.rawgit.com/mulberrysymbols/mulberry-symbols/master/categories.pdf?raw=true) sorted by category (out of date)
+- A [zip of all the symbols](https://github.com/mulberrysymbols/mulberry-symbols/releases/latest) in SVG format, including a spreadsheet with categories, tags and rating (large file)
+- A [PDF of the symbols](https://github.com/mulberrysymbols/mulberry-symbols/releases/latest) sorted by category (out of date)
 
-# Licence
+# License
 
-These symbols are published under the [Creative Commons BY-SA](https://github.com/mulberrysymbols/mulberry-symbols/blob/master/LICENSE.txt) license. You can use the symbols in any project or product, commercial or otherwise as long as any distribution gives us clear attribution and the symbols are shared under the same licence.
+These symbols are published under the [Creative Commons BY-SA](https://github.com/mulberrysymbols/mulberry-symbols/blob/master/LICENSE.txt) license. You can use the symbols in any project or product, commercial or otherwise as long as any distribution gives us clear attribution and the symbols are shared under the same license.
 
 So, you are free to reproduce these symbols and distribute them or derivatives in printed or electronic form. For example, in a printed communication document or board, a website, app or marketing material. While you may charge for your product or added value, you must not charge for the symbols themselves. They are to remain free of cost and freely available to all.
 
-We do encourage you to modify and enhance the symbols so that they are even more useful. We'd love you to contribute your changes back to us on GitHub but you are not required to do so. The licence alows us to find and publish your changes anyway but we'd much prefer to work directly with you. 
+We do encourage you to modify and enhance the symbols so that they are even more useful. We'd love you to contribute your changes back to us on GitHub but you are not required to do so. The license allows us to find and publish your changes anyway but we'd much prefer to work directly with you.
 
 You can easily attribute us with a link to this website plus a mention of Mulberry Symbols.
 
 # Developers
 
-* [Open in GitHub](https://github.com/mulberrysymbols/mulberry-symbols)
+- [Open in GitHub](https://github.com/mulberrysymbols/mulberry-symbols)
 
 # The Symbols in Use
 
-Here's a list of uses that we know about . Please let us know of others so we can add them.
+Here's a list of uses that we know about. Please let us know of others so we can add them.
 
-* [cboard](https://www.cboard.io/) is an open source communication web app using symbols and text to speech.
-* [Global Symbols](https://globalsymbols.com/en/home/) provides a dictionary of international communications symbols, including ARASAAC and Tawasol.
-* [AlwaysInMind](https://alwaysinmind.info) is a web app for simplified and managed access to media and communications.
+- [cboard](https://www.cboard.io/) is an open source communication web app using symbols and text to speech.
+- [Global Symbols](https://globalsymbols.com/en/home/) provides a dictionary of international communications symbols, including ARASAAC and Tawasol.
+- [AlwaysInMind](https://alwaysinmind.info) is a web app for simplified and managed access to media and communications.
 
 # Contact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 We believe that communication is a fundamental human right. Many people with impaired speech and other language difficulties require symbols to support their communication needs, to enable their desires, wishes and opinions to be expressed.
 
-These symbols are provided as a "free at the point of use" resource for speech and language professionals (SLTs) or developers to use in communication aids or to print. We also hope exciting new uses will be created so we have used a liberal Creative Commons license.
+These symbols are provided as a "free at the point of use" resource for speech and language professionals (SLTs) or developers to use in communication aids or to print. We also hope exciting new uses will be created so we have used a liberal Creative Commons licence.
 
 - Designed to overcome high costs experienced by symbols users - free at point of use
 - Foster innovation by allowing reuse and derivations, including internationalisation and use in web apps.
@@ -16,13 +16,13 @@ These symbols are provided as a "free at the point of use" resource for speech a
 - A [zip of all the symbols](https://github.com/mulberrysymbols/mulberry-symbols/releases/latest) in SVG format, including a spreadsheet with categories, tags and rating (large file)
 - A [PDF of the symbols](https://github.com/mulberrysymbols/mulberry-symbols/releases/latest) sorted by category (out of date)
 
-# License
+# Licence
 
-These symbols are published under the [Creative Commons BY-SA](https://github.com/mulberrysymbols/mulberry-symbols/blob/master/LICENSE.txt) license. You can use the symbols in any project or product, commercial or otherwise as long as any distribution gives us clear attribution and the symbols are shared under the same license.
+These symbols are published under the [Creative Commons BY-SA](https://github.com/mulberrysymbols/mulberry-symbols/blob/master/LICENSE.txt) licence. You can use the symbols in any project or product, commercial or otherwise as long as any distribution gives us clear attribution and the symbols are shared under the same licence.
 
 So, you are free to reproduce these symbols and distribute them or derivatives in printed or electronic form. For example, in a printed communication document or board, a website, app or marketing material. While you may charge for your product or added value, you must not charge for the symbols themselves. They are to remain free of cost and freely available to all.
 
-We do encourage you to modify and enhance the symbols so that they are even more useful. We'd love you to contribute your changes back to us on GitHub but you are not required to do so. The license allows us to find and publish your changes anyway but we'd much prefer to work directly with you.
+We do encourage you to modify and enhance the symbols so that they are even more useful. We'd love you to contribute your changes back to us on GitHub but you are not required to do so. The licence allows us to find and publish your changes anyway but we'd much prefer to work directly with you.
 
 You can easily attribute us with a link to this website plus a mention of Mulberry Symbols.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "archiver": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
@@ -42,6 +51,12 @@
       "requires": {
         "lodash": "^4.17.10"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -113,6 +128,19 @@
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "dev": true,
+      "optional": true
+    },
     "compress-commons": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
@@ -130,6 +158,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -162,6 +202,15 @@
       "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA==",
       "dev": true
     },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -169,6 +218,42 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "fs-constants": {
@@ -202,6 +287,45 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "ieee754": {
       "version": "1.1.12",
@@ -246,6 +370,12 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -254,6 +384,29 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -273,10 +426,40 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "process-nextick-args": {
@@ -284,6 +467,51 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
+    "puppeteer": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.11.0.tgz",
+      "integrity": "sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -306,10 +534,25 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "string_decoder": {
@@ -342,6 +585,23 @@
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -354,11 +614,29 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "ws": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,32 +14,37 @@
       }
     },
     "archiver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
-      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.0.0.tgz",
+      "integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
+        "archiver-utils": "^2.0.0",
         "async": "^2.0.0",
         "buffer-crc32": "^0.2.1",
         "glob": "^7.0.0",
-        "lodash": "^4.8.0",
         "readable-stream": "^2.0.0",
         "tar-stream": "^1.5.0",
-        "zip-stream": "^1.2.0"
+        "zip-stream": "^2.0.1"
       }
     },
     "archiver-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.0.0.tgz",
+      "integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.toarray": "^4.4.0",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^2.0.0"
       }
     },
@@ -91,9 +96,9 @@
       }
     },
     "buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
-      "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -151,6 +156,17 @@
         "crc32-stream": "^2.0.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "concat-map": {
@@ -197,9 +213,9 @@
       }
     },
     "csv-parse": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.5.0.tgz",
-      "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.3.0.tgz",
+      "integrity": "sha512-vrZTSMG/6a5EI30ICFU8IQ1kR3xXXoC3Z7jaUv76E5uCgFahr2sffRoTAffvEd1JZNssAgalI4DaEFUnXqQCGw==",
       "dev": true
     },
     "debug": {
@@ -283,9 +299,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "handlebars": {
@@ -370,6 +386,48 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
+    },
     "mime": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
@@ -409,13 +467,10 @@
       "dev": true
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -565,17 +620,17 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
         "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
+        "buffer-alloc": "^1.2.0",
         "end-of-stream": "^1.0.0",
         "fs-constants": "^1.0.0",
         "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
+        "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
       }
     },
@@ -639,14 +694,13 @@
       }
     },
     "zip-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.0.1.tgz",
+      "integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
+        "archiver-utils": "^2.0.0",
         "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,18 @@
   "version": "1.0.0",
   "description": "The Mulberry open symbol set is designed to be an alternative set for adult AAC users and is freely usable in on-line applications due to a permissive licence.",
   "main": "gulpfile.js",
+  "engines": {
+    "node": ">=8.0"
+  },
+  "engineStrict": true,
   "directories": {
     "doc": "docs"
   },
   "scripts": {
     "test": "node scripts/reconcile.js",
-    "build": "npm run build:zip && npm run build:pdf",
-    "build:zip": "node scripts/mkzip.js",
-    "build:pdf": "node scripts/mkpdf.js"
+    "build": "npm run build:pdf && npm run build:zip",
+    "build:pdf": "node scripts/mkpdf.js",
+    "build:zip": "node scripts/mkzip.js"
   },
   "repository": {
     "type": "git",
@@ -24,8 +28,8 @@
   },
   "homepage": "https://github.com/straight-street/mulberry-symbols#readme",
   "devDependencies": {
-    "archiver": "^2.1.1",
-    "csv-parse": "^2.5.0",
+    "archiver": "^3.0.0",
+    "csv-parse": "^4.3.0",
     "handlebars": "^4.0.12",
     "puppeteer": "^1.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "test": "node scripts/reconcile.js",
-    "build": "node scripts/mkzip.js"
+    "build": "npm run build:zip && npm run build:pdf",
+    "build:zip": "node scripts/mkzip.js",
+    "build:pdf": "node scripts/mkpdf.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +25,9 @@
   "homepage": "https://github.com/straight-street/mulberry-symbols#readme",
   "devDependencies": {
     "archiver": "^2.1.1",
-    "csv-parse": "^2.5.0"
-  }
+    "csv-parse": "^2.5.0",
+    "handlebars": "^4.0.12",
+    "puppeteer": "^1.11.0"
+  },
+  "dependencies": {}
 }

--- a/scripts/mkpdf.js
+++ b/scripts/mkpdf.js
@@ -45,7 +45,7 @@ async function asyncGenerateHtmlContent(data) {
 
     const categoryTemplate = {
       name: convertToDisplayString(name),
-      content: iconContent
+      content: encodeURIComponent(iconContent)
     };
 
     if (categories[category] === undefined) {

--- a/scripts/mkpdf.js
+++ b/scripts/mkpdf.js
@@ -1,0 +1,118 @@
+const fs = require("fs");
+const path = require("path");
+const util = require("util");
+const puppeteer = require("puppeteer");
+const handlebars = require("handlebars");
+const parse = require("csv-parse");
+
+const asyncReadFile = util.promisify(fs.readFile);
+const SVG_BASE_PATH = path.resolve(__dirname, "..", "EN");
+const PDF_TEMPLATE_PATH = path.resolve(__dirname, "pdf-template.html");
+const CSV_PATH = path.resolve(__dirname, "..", "symbol-info.csv");
+const NAME_INDEX = 1;
+const CATEGORY_INDEX = 3;
+const CATEGORIES_PDF_FILE_NAME = "categories.pdf";
+
+/**
+ * Convert an icon name to a human-readable string
+ *
+ * @param {string} originalString
+ */
+function convertToDisplayString(originalString) {
+  return originalString.replace(/_/g, " ");
+}
+
+/**
+ * Generate HTML content of the PDF report
+ *
+ * @param {*} data
+ */
+async function asyncGenerateHtmlContent(data) {
+  const categories = {};
+
+  for (const row of data) {
+    let category = row[CATEGORY_INDEX];
+
+    if (category === "") {
+      category = "Uncatagorized";
+    }
+
+    const name = row[NAME_INDEX];
+    const iconContent = await asyncReadFile(
+      path.resolve(SVG_BASE_PATH, `${name}.svg`),
+      "utf8"
+    );
+
+    const categoryTemplate = {
+      name: convertToDisplayString(name),
+      content: iconContent
+    };
+
+    if (categories[category] === undefined) {
+      categories[category] = [categoryTemplate];
+    } else {
+      categories[category].push(categoryTemplate);
+    }
+  }
+
+  const sortedCategories = {};
+
+  for (const category of Object.keys(categories).sort()) {
+    sortedCategories[category] = categories[category];
+  }
+
+  const content = await asyncReadFile(PDF_TEMPLATE_PATH, "utf8");
+  const template = handlebars.compile(content);
+
+  return template({
+    categories: sortedCategories
+  });
+}
+
+/**
+ * Parse content of CSV file
+ */
+async function asyncParseCSV() {
+  const csvContents = await asyncReadFile(CSV_PATH, "utf8");
+
+  return new Promise((resolve, reject) => {
+    parse(csvContents, { from: 2, cast: true }, (err, data) => {
+      if (err) {
+        reject(err);
+      }
+
+      resolve(data);
+    });
+  });
+}
+
+/**
+ * Generate PDF
+ */
+async function asyncGeneratePDF() {
+  const csvData = await asyncParseCSV();
+  const html = await asyncGenerateHtmlContent(csvData);
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  await page.setContent(html);
+  await page.pdf({
+    path: CATEGORIES_PDF_FILE_NAME,
+    margin: { top: 24, right: 24, bottom: 24, left: 24 }
+  });
+  await browser.close();
+}
+
+/**
+ * IIFE to allow async/await syntax
+ */
+(async () => {
+  try {
+    console.log("Creating Categories PDF (this may take a few moments)...");
+    await asyncGeneratePDF();
+    console.log(`PDF created: "${CATEGORIES_PDF_FILE_NAME}"`);
+  } catch (err) {
+    console.log("Unable to create Categories PDF");
+    console.log(err);
+  }
+})();

--- a/scripts/mkzip.js
+++ b/scripts/mkzip.js
@@ -1,57 +1,58 @@
 // require modules
-var fs = require('fs');
-var archiver = require('archiver');
- 
-VERSION = '3.2'
+var fs = require("fs");
+var archiver = require("archiver");
+
+VERSION = "3.2";
 
 // create a file to stream archive data to.
 var output = fs.createWriteStream(`mulberry-symbols.zip`);
-var archive = archiver('zip', {
+var archive = archiver("zip", {
   zlib: { level: 9 } // Sets the compression level.
 });
- 
+
 // listen for all archive data to be written
 // 'close' event is fired only when a file descriptor is involved
-output.on('close', function() {
-  console.log(archive.pointer() + ' total bytes added to archive');
+output.on("close", function() {
+  console.log(archive.pointer() + " total bytes added to archive");
 });
- 
+
 // This event is fired when the data source is drained no matter what was the data source.
 // It is not part of this library but rather from the NodeJS Stream API.
 // @see: https://nodejs.org/api/stream.html#stream_event_end
-output.on('end', function() {
-  console.log('Data has been drained');
+output.on("end", function() {
+  console.log("Data has been drained");
 });
- 
+
 // good practice to catch warnings (ie stat failures and other non-blocking errors)
-archive.on('warning', function(err) {
-  if (err.code === 'ENOENT') {
-    console.log(err)
+archive.on("warning", function(err) {
+  if (err.code === "ENOENT") {
+    console.log(err);
     // log warning
   } else {
     // throw error
     throw err;
   }
 });
- 
+
 // good practice to catch this error explicitly
-archive.on('error', function(err) {
+archive.on("error", function(err) {
   throw err;
 });
- 
+
 // pipe archive data to the file
 archive.pipe(output);
- 
+
 // append a file from string
-archive.append(`Mulberry Symbols version: ${VERSION}`, { name: 'VERSION.txt' })
+archive.append(`Mulberry Symbols version: ${VERSION}`, { name: "VERSION.txt" });
 
 // append a files
-archive.file('LICENSE.txt', { name: 'LICENSE.txt' });
-archive.file('symbol-info.csv', { name: 'symbol-info.csv' });
- 
+archive.file("LICENSE.txt", { name: "LICENSE.txt" });
+archive.file("symbol-info.csv", { name: "symbol-info.csv" });
+archive.file("categories.pdf", { name: "categories.pdf" });
+
 // append files from a sub-directory and naming it `new-subdir` within the archive
-archive.directory('EN/', 'EN-symbols');
-  
+archive.directory("EN/", "EN-symbols");
+
 // finalize the archive (ie we are done appending files but streams have to finish yet)
 // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
 archive.finalize();

--- a/scripts/pdf-template.html
+++ b/scripts/pdf-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -24,7 +24,7 @@
         text-align: center;
       }
 
-      .icon__svg svg {
+      .icon__svg {
         width: 60px !important;
         height: 60px !important;
       }
@@ -40,7 +40,11 @@
     <div class="container">
       {{#each this}}
       <div class="icon">
-        <div class="icon__svg">{{{ this.content }}}</div>
+        <img
+          class="icon__svg"
+          src="data:image/svg+xml;utf8,{{{ this.content }}}"
+          alt="{{ this.name }} symbol"
+        />
         <div class="icon__title">{{ this.name }}</div>
       </div>
       {{/each}}

--- a/scripts/pdf-template.html
+++ b/scripts/pdf-template.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Mulberry Symbol Set - Categories</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      html {
+        padding: 0;
+        margin: 0;
+        font-family: sans-serif;
+      }
+
+      .container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
+
+      .icon {
+        width: 60px;
+        margin: 8px;
+        text-align: center;
+      }
+
+      .icon__svg svg {
+        width: 60px !important;
+        height: 60px !important;
+      }
+
+      .icon__title {
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    {{#each categories}}
+    <h2>{{ @key }}</h2>
+    <div class="container">
+      {{#each this}}
+      <div class="icon">
+        <div class="icon__svg">{{{ this.content }}}</div>
+        <div class="icon__title">{{ this.name }}</div>
+      </div>
+      {{/each}}
+    </div>
+    {{/each}}
+  </body>
+</html>


### PR DESCRIPTION
👋 Hello! I've been looking through the Mulberry Symbol set for some time and was hoping to help  contribute by helping close #12 

## Description

This PR introduces a new utility script `mkpdf.js` which is ran during the `npm run build` script. It accomplishes the following:

- Parses the `symbol-info.csv` file to organize all SVGs by category
  - Icons that are missing a category are placed under `Uncategorized`
- Generates a PDF with a combination of [puppeteer](https://www.npmjs.com/package/puppeteer) and [handlebars](https://www.npmjs.com/package/handlebars)

I used this as an excuse to try out several PDF generation libraries in node.js, including [pdfkit](https://www.npmjs.com/package/pdfkit) and [pdfmake](https://www.npmjs.com/package/pdfmake), but the vector/SVG support is very limited. The Puppeteer approach ended up being much simpler and looked better.

### PDF Sample

Here is an example of the PDF that is generated: [categories.pdf](https://github.com/mulberrysymbols/mulberry-symbols/files/2719760/categories.pdf)

<img width="500" alt="screen shot 2019-01-01 at 7 23 36 pm" src="https://user-images.githubusercontent.com/4030377/50578118-c0414980-0dfa-11e9-8108-bc4d87d99a0d.png">

I've also updated the documentation to include the additional step of adding the PDF to the Github release.  Let me know what you think!

