### PR TITLE
Include the version number in the PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ If you want to develop the website locally follow the instructions on [Githubs d
 
 ## Releases
 
-Currently this is a manual process. The following updates the zip and category files ready for the release 
+Currently this is a manual process. The following updates the zip and category files ready for the release
 
-1. Update the RELEASE number in `scripts/mkzip.js`
+1. Update the version number in `package.json`
 1. Commit and push everything so merged to master on GitHub
 1. Execute `npm run build` to build the zip and categories files
 1. Make a GitHub Release with Tag of `v<RELEASE NUMBER>`, adding release notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "straight-street",
-  "version": "1.0.0",
+  "version": "3.4.0",
   "description": "The Mulberry open symbol set is designed to be an alternative set for adult AAC users and is freely usable in on-line applications due to a permissive licence.",
   "main": "gulpfile.js",
   "engines": {

--- a/scripts/mkhtml.js
+++ b/scripts/mkhtml.js
@@ -96,7 +96,10 @@ async function asyncGenerateHtmlContent(data) {
   });
 
   const html = htmlTemplate({ content });
-  const pdf = pdfTemplate({ content });
+  const pdf = pdfTemplate({
+    content,
+    version: require('../package.json').version,
+  });
 
   await asyncWriteFile(CATEGORIES_HTML_FILE_NAME, html);
 

--- a/scripts/mkzip.js
+++ b/scripts/mkzip.js
@@ -1,31 +1,31 @@
 // require modules
-var fs = require("fs");
-var archiver = require("archiver");
+var fs = require('fs');
+var archiver = require('archiver');
 
-VERSION = "3.4";
+VERSION = require('../package.json').version;
 
 // create a file to stream archive data to.
 var output = fs.createWriteStream(`mulberry-symbols.zip`);
-var archive = archiver("zip", {
-  zlib: { level: 9 } // Sets the compression level.
+var archive = archiver('zip', {
+  zlib: { level: 9 }, // Sets the compression level.
 });
 
 // listen for all archive data to be written
 // 'close' event is fired only when a file descriptor is involved
-output.on("close", function() {
-  console.log(archive.pointer() + " total bytes added to archive");
+output.on('close', function() {
+  console.log(archive.pointer() + ' total bytes added to archive');
 });
 
 // This event is fired when the data source is drained no matter what was the data source.
 // It is not part of this library but rather from the NodeJS Stream API.
 // @see: https://nodejs.org/api/stream.html#stream_event_end
-output.on("end", function() {
-  console.log("Data has been drained");
+output.on('end', function() {
+  console.log('Data has been drained');
 });
 
 // good practice to catch warnings (ie stat failures and other non-blocking errors)
-archive.on("warning", function(err) {
-  if (err.code === "ENOENT") {
+archive.on('warning', function(err) {
+  if (err.code === 'ENOENT') {
     console.log(err);
     // log warning
   } else {
@@ -35,7 +35,7 @@ archive.on("warning", function(err) {
 });
 
 // good practice to catch this error explicitly
-archive.on("error", function(err) {
+archive.on('error', function(err) {
   throw err;
 });
 
@@ -43,17 +43,17 @@ archive.on("error", function(err) {
 archive.pipe(output);
 
 // append a file from string
-archive.append(`Mulberry Symbols version: ${VERSION}`, { name: "VERSION.txt" });
+archive.append(`Mulberry Symbols version: ${VERSION}`, { name: 'VERSION.txt' });
 
 // append a files
-archive.file("LICENSE.txt", { name: "LICENSE.txt" });
-archive.file("symbol-info.csv", { name: "symbol-info.csv" });
-archive.file("categories/categories.pdf", {
-  name: "categories.pdf"
+archive.file('LICENSE.txt', { name: 'LICENSE.txt' });
+archive.file('symbol-info.csv', { name: 'symbol-info.csv' });
+archive.file('categories/categories.pdf', {
+  name: 'categories.pdf',
 });
 
 // append files from a sub-directory and naming it `new-subdir` within the archive
-archive.directory("EN/", "EN-symbols");
+archive.directory('EN/', 'EN-symbols');
 
 // finalize the archive (ie we are done appending files but streams have to finish yet)
 // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand

--- a/scripts/templates/pdf-template.html
+++ b/scripts/templates/pdf-template.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
+    <p>Version: {{ version }}</p>
     {{{ content }}}
   </body>
 </html>


### PR DESCRIPTION
In order to abstract the version so that it can be used by multiple scripts it was moved to the `package.json` file. The README was changed to reflect that.