### PR TITLE
Add Symbol-It to "The Symbols In Use" Section on Website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@ Here's a list of places we know about that use Mulberry Symbols. Please let us k
 - [Global Symbols](https://globalsymbols.com) provides a dictionary of international communications symbols, including ARASAAC and Tawasol.
 - [Commtap Symboliser for PowerPoint](https://symboliser.commtap.org/) is a commercial tool making it easy to add symbols to text.
 - [AlwaysInMind](https://alwaysinmind.info) is a web app for simplified and managed access to media and communications.
+- [Symbol-It](https://symbolspeak.co/) is a mobile app that allows you to easily immerse a symbol speaker in their symbol system by facilitating real-time speech to AAC symbol conversion.
 
 ## Thanks and Acknowledgements
 


### PR DESCRIPTION
## Add Symbol-It to _The Symbols In Use_ Section on Website

This PR adds a link to the Mulberry Symbols website to the website for Symbol-It, an app that facilitates real-time speech to AAC symbol conversion. The Mulberry Symbols were included in the app with attribution in Symbol-It's version 1.2.7, released on October 25, 2019.